### PR TITLE
feat: starts handling withdraw many

### DIFF
--- a/src/mappings/hub.ts
+++ b/src/mappings/hub.ts
@@ -38,12 +38,15 @@ export function handleTerminated(event: Terminated): void {
 
 export function handleWithdrew(event: Withdrew): void {
   let transaction = transactionLibrary.getOrCreateFromEvent(event, 'Withdrew');
-  positionLibrary.withdrew(event, transaction);
+  positionLibrary.withdrew(event.params.positionId.toString(), transaction);
 }
 
 export function handleWithdrewMany(event: WithdrewMany): void {
   let transaction = transactionLibrary.getOrCreateFromEvent(event, 'WithdrewMany');
-  // positionLibrary.getOrCreate(event, transaction);
+  let positions = event.params.positions;
+  for (let i: i32 = 0; i < positions.length; i++) {
+    positionLibrary.withdrew(event.params.positions[1].toString(), transaction);
+  }
 }
 
 export function handleSwapped(event: Swapped): void {

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -144,17 +144,17 @@ export function terminated(event: Terminated, transaction: Transaction): Positio
   return position;
 }
 
-export function withdrew(event: Withdrew, transaction: Transaction): Position {
-  let id = event.params.positionId.toString();
-  log.info('[Position] Withdrew {}', [id]);
-  let position = getById(id);
+export function withdrew(positionId: string, transaction: Transaction): Position {
+  log.info('[Position] Withdrew {}', [positionId]);
+  let position = getById(positionId);
+  let currentState = positionStateLibrary.get(position.current);
   // Position state
-  positionStateLibrary.registerWithdrew(position.current, event.params.amount);
-  position.totalWithdrawn = position.totalWithdrawn.plus(event.params.amount);
+  positionStateLibrary.registerWithdrew(position.current, currentState.idleSwapped);
+  position.totalWithdrawn = position.totalWithdrawn.plus(currentState.idleSwapped);
   position.save();
   //
   // Position action
-  positionActionLibrary.withdrew(id, event.params.amount, transaction);
+  positionActionLibrary.withdrew(positionId, currentState.idleSwapped, transaction);
   //
   return position;
 }


### PR DESCRIPTION
Adapted `positionLibrary.withdrew` to stop using amount sent by event, since if `idleSwapped` its correctly calculated, this code should work.
Also on `withdrawMany` only way of knowing the amount of every position is just using `idleSwapped`.