### PR TITLE
refactor: general miscellaneous

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -134,13 +134,13 @@ type PairSwap @entity {
   "pair swap intervals"
   pairSwapsIntervals: [PairSwapInterval!]! @derivedFrom(field: "pairSwap")
   "ratio unit b to a"
-  ratioPerUnitBToA: BigInt!
+  ratioBToA: BigInt!
   "ratio unit b to a with fee subtracted"
-  ratioPerUnitBToAWithFee: BigInt!
+  ratioBToAWithFee: BigInt!
   "ratio unit a to b"
-  ratioPerUnitAToB: BigInt!
+  ratioAToB: BigInt!
   "ratio unit a to b with fee subtracted"
-  ratioPerUnitAToBWithFee: BigInt!
+  ratioAToBWithFee: BigInt!
   "executed with transaction"
   transaction: Transaction!
   "executed at block number"
@@ -286,9 +286,9 @@ type SwappedAction implements PositionActionInterface @entity {
   rateUnderlying: BigInt
 
   "ratio unit b to a with fee subtracted"
-  ratioPerUnitBToAWithFee: BigInt!
+  ratioBToAWithFee: BigInt!
   "ratio unit a to b with fee subtracted"
-  ratioPerUnitAToBWithFee: BigInt!
+  ratioAToBWithFee: BigInt!
 
   "transaction"
   transaction: Transaction!

--- a/src/utils/pair-swap.ts
+++ b/src/utils/pair-swap.ts
@@ -11,10 +11,10 @@ export function create(pair: Pair, event: SwappedSwapInformationPairsStruct, tra
     pairSwap = new PairSwap(pairSwapId);
     pairSwap.pair = pair.id;
     pairSwap.swapper = transaction.from;
-    pairSwap.ratioPerUnitBToA = event.ratioBToA;
-    pairSwap.ratioPerUnitBToAWithFee = APPLY_FEE(fee, event.ratioBToA);
-    pairSwap.ratioPerUnitAToB = event.ratioAToB;
-    pairSwap.ratioPerUnitAToBWithFee = APPLY_FEE(fee, event.ratioAToB);
+    pairSwap.ratioBToA = event.ratioBToA;
+    pairSwap.ratioBToAWithFee = APPLY_FEE(fee, event.ratioBToA);
+    pairSwap.ratioAToB = event.ratioAToB;
+    pairSwap.ratioAToBWithFee = APPLY_FEE(fee, event.ratioAToB);
     pairSwap.transaction = transaction.id;
     pairSwap.executedAtBlock = transaction.blockNumber;
     pairSwap.executedAtTimestamp = transaction.timestamp;

--- a/src/utils/position-action.ts
+++ b/src/utils/position-action.ts
@@ -210,8 +210,8 @@ export function swapped(position: Position, swapped: BigInt, rate: BigInt, pairS
     positionAction.rate = rate;
     positionAction.swapped = swapped;
 
-    positionAction.ratioPerUnitAToBWithFee = pairSwap.ratioPerUnitAToBWithFee;
-    positionAction.ratioPerUnitBToAWithFee = pairSwap.ratioPerUnitBToAWithFee;
+    positionAction.ratioAToBWithFee = pairSwap.ratioAToBWithFee;
+    positionAction.ratioBToAWithFee = pairSwap.ratioBToAWithFee;
 
     // Check yield-bearing-share on from
     if (from.type == 'YIELD_BEARING_SHARE') {

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -229,7 +229,7 @@ export function registerPairSwap(positionId: string, pair: Pair, pairSwap: PairS
   const from = tokenLibrary.getById(position.from);
   const to = tokenLibrary.getById(position.to);
 
-  const ratioFromTo = position.from == pair.tokenA ? pairSwap.ratioPerUnitAToBWithFee : pairSwap.ratioPerUnitBToAWithFee;
+  const ratioFromTo = position.from == pair.tokenA ? pairSwap.ratioAToBWithFee : pairSwap.ratioBToAWithFee;
   const swapped = ratioFromTo.times(position.rate).div(from.magnitude);
 
   position.remainingSwaps = position.remainingSwaps.minus(ONE_BI);

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -26,7 +26,7 @@ export function getOrCreate(tokenAddress: Address, allowed: boolean): Token {
   const id = tokenAddress.toHexString();
   log.info('[Tokens] Get or create {}', [id]);
   let token = Token.load(id);
-  if (token === null) {
+  if (token == null) {
     if (tokenAddress.equals(PROTOCOL_TOKEN_ADDRESS)) {
       token = createProtocolToken();
     } else {
@@ -106,7 +106,7 @@ export function getUnderlyingTokenIds(transformerAddress: Address, dependantToke
   for (let i: i32 = 0; i < underlyingTokenAddresses.length; i++) {
     const underlyingId = underlyingTokenAddresses[i].toHexString();
     const underlyingToken = Token.load(underlyingId);
-    if (underlyingToken === null) getOrCreate(underlyingTokenAddresses[i], false);
+    if (underlyingToken == null) getOrCreate(underlyingTokenAddresses[i], false);
     underlyingTokens.push(underlyingId);
   }
   return underlyingTokens;


### PR DESCRIPTION
- Stop using operator triple equal
- Renames `ratioPerUnit` to `ratioAToB` and so on, to be similar like we do on-chain. 